### PR TITLE
feat(argocd): move system-upgrade into platform

### DIFF
--- a/kubernetes/apps/argocd/kustomization.yaml
+++ b/kubernetes/apps/argocd/kustomization.yaml
@@ -15,6 +15,5 @@ resources:
   - ./registry/openebs-system.yaml
   - ./registry/paperless.yaml
   - ./registry/rook-ceph.yaml
-  - ./registry/system-upgrade.yaml
   - ./registry/teleport.yaml
   - ./registry/volsync-system.yaml

--- a/kubernetes/argocd/platform/kustomization.yaml
+++ b/kubernetes/argocd/platform/kustomization.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  - system-upgrade.yaml

--- a/kubernetes/argocd/platform/system-upgrade.yaml
+++ b/kubernetes/argocd/platform/system-upgrade.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-upgrade
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    volsync.backube/privileged-movers: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+    volsync.backube/privileged-movers: "true"
+---
+# Helm-based System Upgrade Apps
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: system-upgrade-helm-apps
+  namespace: argocd
+spec:
+  syncPolicy:
+    applicationsSync: create-update
+    preserveResourcesOnDeletion: true
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - app: tuppr
+            path: kubernetes/apps/system-upgrade/tuppr
+            chart: tuppr
+            repo: oci://ghcr.io/home-operations/charts/tuppr
+            version: 0.1.3
+  template:
+    metadata:
+      name: "{{.app}}"
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{ .wave | default "0" }}'
+    spec:
+      project: home-ops
+      sources:
+        - repoURL: https://github.com/binaryn3xus/HomeOps
+          targetRevision: main
+          ref: values
+        - repoURL: https://github.com/binaryn3xus/HomeOps
+          targetRevision: main
+          path: "{{.path}}"
+        - repoURL: "{{.repo}}"
+          chart: "{{.chart}}"
+          targetRevision: "{{.version}}"
+          helm:
+            releaseName: "{{.app}}"
+            valueFiles:
+              - $values/{{.path}}/values.yaml
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: system-upgrade
+      syncPolicy:
+        automated:
+          enabled: false
+          prune: false
+          selfHeal: false
+        syncOptions:
+          - ServerSideApply=true
+---
+# Plain Manifest System Upgrade Apps
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: system-upgrade-plain-apps
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - app: etcd-defrag
+            path: kubernetes/apps/system-upgrade/etcd-defrag
+  template:
+    metadata:
+      name: "{{.app}}"
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{ .wave | default "0" }}'
+    spec:
+      project: home-ops
+      source:
+        repoURL: https://github.com/binaryn3xus/HomeOps
+        targetRevision: main
+        path: "{{.path}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: system-upgrade
+      syncPolicy:
+        automated:
+          enabled: false
+          prune: false
+          selfHeal: false
+        syncOptions:
+          - ServerSideApply=true


### PR DESCRIPTION
## Summary
- add system-upgrade registry manifests under kubernetes/argocd/platform
- include system-upgrade in the platform kustomization
- remove system-upgrade from the legacy kubernetes/apps/argocd registry index

## Why
This is the first low-blast-radius migration slice toward the new argocd core/platform/apps split. It avoids touching Teleport, network, cert-manager, and external-secrets while exercising the ownership transfer pattern.

## Notes
- this is still preparatory until the root argocd cutover happens
- sync remains manual/prune disabled for the managed apps
